### PR TITLE
feat: introduce personal sign and transaction related provider methods

### DIFF
--- a/kip-0012.md
+++ b/kip-0012.md
@@ -80,32 +80,107 @@ The following is an example event flow of sending a transaction.
 ### Interface Definitions
 
 ```typescript
-export interface KaspaProvider {
-    request: (method:string,args:any[]) => Promise<any>;
-    connect: () => Promise<void>;
-    disconnect: () => Promise<void>;
+export const KIP12_EVENT_METHOD = "kaspa:event" as const;
+
+export const KIP12_METHODS = [
+  "kaspa:connect",
+  "kaspa:disconnect",
+  "kaspa:send",
+  "kaspa:sign",
+  "kaspa:broadcast",
+  "kaspa:signPersonal",
+  "kaspa:sendTransaction",
+  "kaspa:signTransaction",
+  "kaspa:broadcastTransaction",
+] as const;
+
+export type KIP12Method = (typeof KIP12_METHODS)[number];
+export type KIP12EventMethod = typeof KIP12_EVENT_METHOD;
+
+export interface KIP12ErrorPayload {
+  message: string;
+  code?: string | number;
+  details?: unknown;
 }
 
-
-export interface ProviderInfo {
-    id: string;
-    name: string;
-    icon: string;
-    methods: string[];
+export interface KIP12MethodArgs {
+  "kaspa:connect": [];
+  "kaspa:disconnect": [];
+  "kaspa:send": unknown[];
+  "kaspa:sign": unknown[];
+  "kaspa:broadcast": unknown[];
+  "kaspa:signPersonal": unknown[];
+  "kaspa:sendTransaction": unknown[];
+  "kaspa:signTransaction": unknown[];
+  "kaspa:broadcastTransaction": unknown[];
 }
 
-export interface Message {
-    eventId: string;
-    extensionId: string;
-    method: string;
-    args?: any[];
-    error?: any;
+export interface KIP12MethodResult {
+  "kaspa:connect": unknown;
+  "kaspa:disconnect": unknown;
+  "kaspa:send": unknown;
+  "kaspa:sign": unknown;
+  "kaspa:broadcast": unknown;
+  "kaspa:signPersonal": unknown;
+  "kaspa:sendTransaction": unknown;
+  "kaspa:signTransaction": unknown;
+  "kaspa:broadcastTransaction": unknown;
+}
+
+export type KIP12Args<TMethod extends KIP12Method> = KIP12MethodArgs[TMethod];
+
+export type KIP12Result<TMethod extends KIP12Method> =
+  KIP12MethodResult[TMethod];
+
+export interface KIP12BaseMessage {
+  eventId: string;
+  extensionId?: string;
+}
+
+export interface KIP12RequestMessage<TMethod extends KIP12Method = KIP12Method>
+  extends KIP12BaseMessage {
+  method: TMethod;
+  args?: KIP12Args<TMethod>;
+}
+
+export interface KIP12EventSuccess<TData = unknown> extends KIP12BaseMessage {
+  method: KIP12EventMethod;
+  data: TData;
+  error?: undefined;
+}
+
+export interface KIP12EventError extends KIP12BaseMessage {
+  method: KIP12EventMethod;
+  data?: undefined;
+  error: KIP12ErrorPayload;
+}
+
+export type KIP12EventMessage<TData = unknown> =
+  | KIP12EventSuccess<TData>
+  | KIP12EventError;
+
+export type KIP12ExtensionMessage = KIP12RequestMessage | KIP12EventMessage;
+
+export interface KIP12ProviderInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly icon: string;
+  readonly methods: readonly KIP12Method[];
+}
+
+export interface KIP12Provider {
+  request<TMethod extends KIP12Method>(
+    method: TMethod,
+    args: KIP12Args<TMethod>,
+  ): Promise<KIP12Result<TMethod>>;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
 }
 
 declare global {
-    interface Window {
-        kaspaProvider: KaspaProvider;
-    }
+  interface Window {
+    kaspaProvider?: KIP12Provider;
+  }
 }
 ```
 

--- a/kip-0012.md
+++ b/kip-0012.md
@@ -46,7 +46,7 @@ Wallets and web apps communicate through the browser's `window` object using `Cu
 - **`kaspa:signPersonal`**: Request to sign a personal message using KIP-5.
 - **`kaspa:sendTransaction`**: Request to sign and broadcast a transaction over the Kaspa network.
 - **`kaspa:signTransaction`**: Request to sign a transaction.
-- **`kaspa:broadcastTransaction`**: Request to broadcast a signed transaction.
+- **`kaspa:broadcastTransaction`**: Request to broadcast a signed transaction over the Kaspa network.
 
 The wallet **MUST NOT** react to any requests except the **`kaspa:connect`** event. Only after an explicit connection request **MAY** the wallet react to subsequent requests made by the **Web App**.
 

--- a/kip-0012.md
+++ b/kip-0012.md
@@ -43,6 +43,10 @@ Wallets and web apps communicate through the browser's `window` object using `Cu
 - **`kaspa:send`**: Request to sign and broadcast a PSKB over the Kaspa network.
 - **`kaspa:sign`**: Request to sign a PSKB.
 - **`kaspa:broadcast`**: Request to broadcast a signed PSKB over the Kaspa network.
+- **`kaspa:signPersonal`**: Request to sign a personal message using KIP-5.
+- **`kaspa:sendTransaction`**: Request to sign and broadcast a transaction over the Kaspa network.
+- **`kaspa:signTransaction`**: Request to sign a transaction.
+- **`kaspa:broadcastTransaction`**: Request to broadcast a signed 
 
 The wallet **MUST NOT** react to any requests except the **`kaspa:connect`** event. Only after an explicit connection request **MAY** the wallet react to subsequent requests made by the **Web App**.
 

--- a/kip-0012.md
+++ b/kip-0012.md
@@ -46,7 +46,7 @@ Wallets and web apps communicate through the browser's `window` object using `Cu
 - **`kaspa:signPersonal`**: Request to sign a personal message using KIP-5.
 - **`kaspa:sendTransaction`**: Request to sign and broadcast a transaction over the Kaspa network.
 - **`kaspa:signTransaction`**: Request to sign a transaction.
-- **`kaspa:broadcastTransaction`**: Request to broadcast a signed 
+- **`kaspa:broadcastTransaction`**: Request to broadcast a signed transaction.
 
 The wallet **MUST NOT** react to any requests except the **`kaspa:connect`** event. Only after an explicit connection request **MAY** the wallet react to subsequent requests made by the **Web App**.
 


### PR DESCRIPTION
This proposal introduces 4 new methods:
* `personalSign`: KIP5 compliant personal message signing
* `send|sign|broadcast``Transaction`: same purpose as PSKB but for "basic" transactions

Additionally added stricter typescript interfaces

What's missing:
* define input/output of each methods in a formal way (at least typescript interfaces)